### PR TITLE
Voeg startup map toe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+startup/

--- a/startup/user.yml
+++ b/startup/user.yml
@@ -1,0 +1,9 @@
+# yml file for easier authentication in the future, startup scripts can be put in
+# this folder as well
+
+test:
+    user: null
+    pwd: null
+    url: null
+    port: null
+    db: null


### PR DESCRIPTION
Voegt startup map toe met een placeholder file om later gemakkelijker de server te kunnen starten met één commando. De startup folder kan gebruikt worden om eigen gemaakte opstart-scripts in te bewaren